### PR TITLE
fix: for Erlang/OTP 27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ["24.3", "25.2"]
+        otp: ["24.3", "25.2", "27.0"]
     container: erlang:${{matrix.otp}}
     steps:
       - name: Checkout source
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ["24.3", "25.2"]
+        otp: ["24.3", "25.2", "27.0"]
     container: erlang:${{matrix.otp}}
     steps:
       - name: Checkout source

--- a/src/crontab_server.erl
+++ b/src/crontab_server.erl
@@ -32,7 +32,7 @@
 
 %%%_* Macros ===========================================================
 -define(tick, 1000).
--define(REPORT(Msg, Job), #{message => Msg, cronjob => Job}).
+-define(REPORT(Msg, Job), begin #{message => Msg, cronjob => Job} end).
 
 %%%_* Code =============================================================
 %%%_ * Types -----------------------------------------------------------


### PR DESCRIPTION
## Motivation

We're starting to test some of our tools in OTP 27. This is a step in that direction.

## Description

The fixed issue comes from https://github.com/erlang/otp/pull/8069.

## Further considerations

The proposal for change (coverage for lib. tests below) comes from https://github.com/WhatsApp/erlfmt/pull/354 (mentioned in that same issue).

**Note**: we could've not be using a macro for this, but I wanted a small change scope.

### Coverage

```
module          coverage %
crontab         100%
crontab_app     100%
crontab_server  90%
crontab_sup     100%
crontab_time    100%
Total           96%
```